### PR TITLE
Add zero-copy import option for WebGPU

### DIFF
--- a/videoeffect/blur4.html
+++ b/videoeffect/blur4.html
@@ -35,6 +35,9 @@
     <label style="font: 1em sans-serif; display: block; margin-bottom: 10px; padding-left: 20px;" id="zeroCopyLabel">
       <input type="checkbox" id="zeroCopy" name="zeroCopy" unchecked /> Zero-copy import
     </label>
+    <label style="font: 1em sans-serif; display: block; margin-bottom: 10px; padding-left: 20px;" id="directOutputLabel">
+      <input type="checkbox" id="directOutput" name="directOutput" unchecked /> Zero-copy output
+    </label>
     <button id="startButton" style="padding: 10px 20px; font-size: 16px; background-color: #4CAF50; color: white; border: none; border-radius: 5px; cursor: pointer;">
       Start Video Processing
     </button>

--- a/videoeffect/blur4.html
+++ b/videoeffect/blur4.html
@@ -32,6 +32,9 @@
     <label style="font: 1em sans-serif; display: block; margin-bottom: 15px;">
       <input type="radio" name="renderer" value="webgpu" id="webgpuRadio" /> WebGPU (Advanced, requires compatible browser)
     </label>
+    <label style="font: 1em sans-serif; display: block; margin-bottom: 10px; padding-left: 20px;" id="zeroCopyLabel">
+      <input type="checkbox" id="zeroCopy" name="zeroCopy" unchecked /> Zero-copy import
+    </label>
     <button id="startButton" style="padding: 10px 20px; font-size: 16px; background-color: #4CAF50; color: white; border: none; border-radius: 5px; cursor: pointer;">
       Start Video Processing
     </button>

--- a/videoeffect/blur4.js
+++ b/videoeffect/blur4.js
@@ -46,7 +46,8 @@ async function initializeBlurRenderer() {
     const useWebGPU = document.querySelector('input[name="renderer"]:checked').value === 'webgpu';
     try {
       if (useWebGPU && 'gpu' in navigator) {
-        appBlurRenderer = await createWebGPUBlurRenderer(segmenter);
+        const zeroCopy = zeroCopyCheckbox.checked;
+        appBlurRenderer = await createWebGPUBlurRenderer(segmenter, zeroCopy);
         appStatus.innerText = 'Renderer: WebGPU';
         console.log('Using WebGPU for blur rendering');
       } else {
@@ -196,6 +197,8 @@ const appFpsDisplay = document.getElementById('fpsDisplay');
 const appVideo = document.getElementById('webcam');
 const appProcessedVideo = document.getElementById('processedVideo');
 const appCanvas = document.getElementById('output');
+const zeroCopyCheckbox = document.getElementById('zeroCopy');
+const zeroCopyLabel = document.getElementById('zeroCopyLabel');
 
 // Check browser compatibility
 const hasWebGPU = 'gpu' in navigator;
@@ -318,11 +321,21 @@ async function initializeApp() {
   // Handle display size changes
   displaySizeSelect.addEventListener('change', updateDisplaySize);
   
+  const updateOptionState = () => {
+    const isWebGPU = webgpuRadio.checked;
+    zeroCopyCheckbox.disabled = !isWebGPU;
+    zeroCopyLabel.style.color = isWebGPU ? '' : '#aaa';
+  };
+  const changeEventListener = () => {
+    updateOptionState();
+    if (isRunning) rendererSwitchRequested = true;
+  };
+  zeroCopyCheckbox.addEventListener('change', changeEventListener);
   document.querySelectorAll('input[name="renderer"]').forEach(radio => {
-    radio.addEventListener('change', () => {
-      if (isRunning) rendererSwitchRequested = true;
-    });
+    radio.addEventListener('change', changeEventListener);
   });
+
+  updateOptionState();
 }
 
 // Initialize the app

--- a/videoeffect/blur4.js
+++ b/videoeffect/blur4.js
@@ -47,7 +47,8 @@ async function initializeBlurRenderer() {
     try {
       if (useWebGPU && 'gpu' in navigator) {
         const zeroCopy = zeroCopyCheckbox.checked;
-        appBlurRenderer = await createWebGPUBlurRenderer(segmenter, zeroCopy);
+        const directOutput = directOutputCheckbox.checked;
+        appBlurRenderer = await createWebGPUBlurRenderer(segmenter, zeroCopy, directOutput);
         appStatus.innerText = 'Renderer: WebGPU';
         console.log('Using WebGPU for blur rendering');
       } else {
@@ -199,6 +200,8 @@ const appProcessedVideo = document.getElementById('processedVideo');
 const appCanvas = document.getElementById('output');
 const zeroCopyCheckbox = document.getElementById('zeroCopy');
 const zeroCopyLabel = document.getElementById('zeroCopyLabel');
+const directOutputCheckbox = document.getElementById('directOutput');
+const directOutputLabel = document.getElementById('directOutputLabel');
 
 // Check browser compatibility
 const hasWebGPU = 'gpu' in navigator;
@@ -325,12 +328,16 @@ async function initializeApp() {
     const isWebGPU = webgpuRadio.checked;
     zeroCopyCheckbox.disabled = !isWebGPU;
     zeroCopyLabel.style.color = isWebGPU ? '' : '#aaa';
+    directOutputCheckbox.disabled = !isWebGPU;
+    directOutputLabel.style.color = isWebGPU ? '' : '#aaa';
   };
   const changeEventListener = () => {
     updateOptionState();
     if (isRunning) rendererSwitchRequested = true;
   };
   zeroCopyCheckbox.addEventListener('change', changeEventListener);
+  directOutputCheckbox.addEventListener('change', changeEventListener);
+
   document.querySelectorAll('input[name="renderer"]').forEach(radio => {
     radio.addEventListener('change', changeEventListener);
   });

--- a/videoeffect/webgpu-renderer.js
+++ b/videoeffect/webgpu-renderer.js
@@ -1,233 +1,233 @@
 async function renderWithWebGPU(params, videoFrame) {
-    const device = params.device;
-    const webgpuCanvas = params.webgpuCanvas;
-    const width = params.webgpuCanvas.width;
-    const height = params.webgpuCanvas.height;
+  const device = params.device;
+  const webgpuCanvas = params.webgpuCanvas;
+  const width = params.webgpuCanvas.width;
+  const height = params.webgpuCanvas.height;
 
-    // Import external texture.
-    const sourceTexture = device.createTexture({
-        size: [videoFrame.displayWidth, videoFrame.displayHeight, 1],
-        format: 'rgba8unorm',
-        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
-    });
-    device.queue.copyExternalImageToTexture(
-        { source: videoFrame },
-        { texture: sourceTexture },
-        [videoFrame.displayWidth, videoFrame.displayHeight]
-    );
+  // Import external texture.
+  const sourceTexture = device.createTexture({
+    size: [videoFrame.displayWidth, videoFrame.displayHeight, 1],
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  });
+  device.queue.copyExternalImageToTexture(
+    { source: videoFrame },
+    { texture: sourceTexture },
+    [videoFrame.displayWidth, videoFrame.displayHeight]
+  );
 
-    // Scale down input, segment, read back and upload.
-    let maskTexture;
-    {
-      const segmentationWidth = params.segmentationWidth;
-      const segmentationHeight = params.segmentationHeight;
-      const destTexture = device.createTexture({
-          size: [segmentationWidth, segmentationHeight, 1],
-          format: 'rgba8unorm',
-          usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_SRC,
-      });
-      const downscaleBindGroup = device.createBindGroup({
-          layout: params.downscalePipeline.getBindGroupLayout(0),
-          entries: [
-              { binding: 0, resource: sourceTexture.createView() },
-              { binding: 1, resource: params.downscaleSampler },
-              { binding: 2, resource: destTexture.createView() },
-          ],
-      });
-      const commandEncoder = device.createCommandEncoder();
-      const computePass = commandEncoder.beginComputePass();
-      computePass.setPipeline(params.downscalePipeline);
-      computePass.setBindGroup(0, downscaleBindGroup);
-      computePass.dispatchWorkgroups(Math.ceil(segmentationWidth / 8), Math.ceil(segmentationHeight / 8));
-      computePass.end();
-
-      const bufferSize = segmentationWidth * segmentationHeight * 4;
-      const readbackBuffer = device.createBuffer({
-        size: bufferSize,
-        usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
-      });
-      commandEncoder.copyTextureToBuffer(
-        { texture: destTexture },
-        { buffer: readbackBuffer, bytesPerRow: segmentationWidth * 4 },
-        [segmentationWidth, segmentationHeight]
-      );
-      device.queue.submit([commandEncoder.finish()]);
-      await readbackBuffer.mapAsync(GPUMapMode.READ);
-      const pixelData = new Uint8Array(readbackBuffer.getMappedRange().slice(0));
-      const downscaledImageData = new ImageData(new Uint8ClampedArray(pixelData.buffer), segmentationWidth, segmentationHeight);
-      readbackBuffer.unmap();
-      readbackBuffer.destroy();
-      destTexture.destroy();
-
-      // Segment and upload.
-      const segmentation = await segmenter.segmentPeople(downscaledImageData);
-      if (!segmentation || segmentation.length === 0) {
-          console.warn("Segmentation returned no results.");
-          return null;
-      }
-      const maskImageData = await segmentation[0].mask.toImageData();
-      maskTexture = device.createTexture({
-        size: [maskImageData.width, maskImageData.height, 1],
-        format: 'rgba8unorm',
-        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
-      });
-      device.queue.writeTexture(
-        { texture: maskTexture },
-        maskImageData.data,
-        { bytesPerRow: maskImageData.width * 4 },
-        [maskImageData.width, maskImageData.height, 1]
-      );
-    }
-
-    // Always process at full video resolution, ignore display size
-    const processingWidth = videoFrame.displayWidth || 1280;
-    const processingHeight = videoFrame.displayHeight || 720;
-    
-    // Update canvas size only if video resolution actually changed
-    if (webgpuCanvas.width !== processingWidth || webgpuCanvas.height !== processingHeight) {
-      webgpuCanvas.width = processingWidth;
-      webgpuCanvas.height = processingHeight;
-      // Reconfigure context with actual video size
-      context.configure({
-        device: device,
-        format: navigator.gpu.getPreferredCanvasFormat(),
-        alphaMode: 'premultiplied',
-      });
-    }
-
-    const outputTexture = device.createTexture({
-      size: [width, height, 1],
+  // Scale down input, segment, read back and upload.
+  let maskTexture;
+  {
+    const segmentationWidth = params.segmentationWidth;
+    const segmentationHeight = params.segmentationHeight;
+    const destTexture = device.createTexture({
+      size: [segmentationWidth, segmentationHeight, 1],
       format: 'rgba8unorm',
-      usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+      usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_SRC,
     });
-
-    // Update uniform buffer
-    const uniformData = new Float32Array([width, height, 6.0]); // resolution, blurAmount
-    device.queue.writeBuffer(params.uniformBuffer, 0, uniformData);
-
-    // Create bind group
-    const bindGroup = device.createBindGroup({
-      layout: params.computePipeline.getBindGroupLayout(0),
+    const downscaleBindGroup = device.createBindGroup({
+      layout: params.downscalePipeline.getBindGroupLayout(0),
       entries: [
-        {
-          binding: 0,
-          resource: sourceTexture.createView(),
-        },
-        {
-          binding: 1,
-          resource: maskTexture.createView(),
-        },
-        {
-          binding: 2,
-          resource: outputTexture.createView(),
-        },
-        { binding: 3, resource: params.blurSampler },
-        { binding: 4, resource: { buffer: params.uniformBuffer } },
+        { binding: 0, resource: sourceTexture.createView() },
+        { binding: 1, resource: params.downscaleSampler },
+        { binding: 2, resource: destTexture.createView() },
       ],
     });
-
-    // Run compute shader
     const commandEncoder = device.createCommandEncoder();
     const computePass = commandEncoder.beginComputePass();
-    computePass.setPipeline(params.computePipeline);
-    computePass.setBindGroup(0, bindGroup);
-
-    const workgroupCountX = Math.ceil(width / 8);
-    const workgroupCountY = Math.ceil(height / 8);
-    computePass.dispatchWorkgroups(workgroupCountX, workgroupCountY);
+    computePass.setPipeline(params.downscalePipeline);
+    computePass.setBindGroup(0, downscaleBindGroup);
+    computePass.dispatchWorkgroups(Math.ceil(segmentationWidth / 8), Math.ceil(segmentationHeight / 8));
     computePass.end();
-  
-      // DOESN*T WORK, INTERMEDIATE SHADERS ALSO NEED TO USE 
-      //   commandEncoder.copyTextureToTexture(
-      //     { texture: outputTexture }, 
-      //     { texture: context.getCurrentTexture() },
-      //     [width, height]);
 
-    const renderPipeline = device.createRenderPipeline({
-      layout: 'auto',
-      vertex: {
-        module: params.outputRendererVertexShader,
-        entryPoint: 'main',
-      },
-      fragment: {
-        module: params.getOutputRendererFragmentShader(device, width, height),
-        entryPoint: 'main',
-        targets: [{
-          format: navigator.gpu.getPreferredCanvasFormat(),
-        }],
-      },
-      primitive: {
-        topology: 'triangle-list',
-      },
+    const bufferSize = segmentationWidth * segmentationHeight * 4;
+    const readbackBuffer = device.createBuffer({
+      size: bufferSize,
+      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
     });
-
-    const renderBindGroup = device.createBindGroup({
-      layout: renderPipeline.getBindGroupLayout(0),
-      entries: [
-        { binding: 0, resource: outputTexture.createView() },
-        { binding: 1, resource: params.renderSampler },
-      ],
-    });
-
-    // Render to canvas
-    const canvasTexture = params.context.getCurrentTexture();
-    const renderPass = commandEncoder.beginRenderPass({
-      colorAttachments: [{
-        view: canvasTexture.createView(),
-        clearValue: { r: 0, g: 0, b: 0, a: 1 },
-        loadOp: 'clear',
-        storeOp: 'store',
-      }],
-    });
-
-    renderPass.setPipeline(renderPipeline);
-    renderPass.setBindGroup(0, renderBindGroup);
-    renderPass.draw(6);
-    renderPass.end();
-
+    commandEncoder.copyTextureToBuffer(
+      { texture: destTexture },
+      { buffer: readbackBuffer, bytesPerRow: segmentationWidth * 4 },
+      [segmentationWidth, segmentationHeight]
+    );
     device.queue.submit([commandEncoder.finish()]);
+    await readbackBuffer.mapAsync(GPUMapMode.READ);
+    const pixelData = new Uint8Array(readbackBuffer.getMappedRange().slice(0));
+    const downscaledImageData = new ImageData(new Uint8ClampedArray(pixelData.buffer), segmentationWidth, segmentationHeight);
+    readbackBuffer.unmap();
+    readbackBuffer.destroy();
+    destTexture.destroy();
 
-    // Create a new VideoFrame from the processed WebGPU canvas
-    const processedVideoFrame = new VideoFrame(params.webgpuCanvas, {
-      timestamp: videoFrame.timestamp,
-      duration: videoFrame.duration
+    // Segment and upload.
+    const segmentation = await segmenter.segmentPeople(downscaledImageData);
+    if (!segmentation || segmentation.length === 0) {
+      console.warn("Segmentation returned no results.");
+      return null;
+    }
+    const maskImageData = await segmentation[0].mask.toImageData();
+    maskTexture = device.createTexture({
+      size: [maskImageData.width, maskImageData.height, 1],
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
     });
+    device.queue.writeTexture(
+      { texture: maskTexture },
+      maskImageData.data,
+      { bytesPerRow: maskImageData.width * 4 },
+      [maskImageData.width, maskImageData.height, 1]
+    );
+  }
 
-    // Clean up textures
-    sourceTexture.destroy();
-    maskTexture.destroy();
-    outputTexture.destroy();
+  // Always process at full video resolution, ignore display size
+  const processingWidth = videoFrame.displayWidth || 1280;
+  const processingHeight = videoFrame.displayHeight || 720;
 
-    return processedVideoFrame;
-}
-
-// WebGPU blur renderer
-async function createWebGPUBlurRenderer(segmenter) {
-    // Always use full resolution for processing, regardless of display size
-    const webgpuCanvas = new OffscreenCanvas(1280, 720);
-    
-    const adapter = await navigator.gpu.requestAdapter();
-    if (!adapter) {
-      throw new Error('WebGPU adapter not available');
-    }
-    
-    const device = await adapter.requestDevice();
-    const context = webgpuCanvas.getContext('webgpu');
-    
-    if (!context) {
-      throw new Error('WebGPU context not available');
-    }
-    
+  // Update canvas size only if video resolution actually changed
+  if (webgpuCanvas.width !== processingWidth || webgpuCanvas.height !== processingHeight) {
+    webgpuCanvas.width = processingWidth;
+    webgpuCanvas.height = processingHeight;
+    // Reconfigure context with actual video size
     context.configure({
       device: device,
       format: navigator.gpu.getPreferredCanvasFormat(),
       alphaMode: 'premultiplied',
     });
+  }
 
-    const segmentationWidth = 256;
-    const segmentationHeight = 144;
+  const outputTexture = device.createTexture({
+    size: [width, height, 1],
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  });
 
-    const downscaleShaderCode = `
+  // Update uniform buffer
+  const uniformData = new Float32Array([width, height, 6.0]); // resolution, blurAmount
+  device.queue.writeBuffer(params.uniformBuffer, 0, uniformData);
+
+  // Create bind group
+  const bindGroup = device.createBindGroup({
+    layout: params.computePipeline.getBindGroupLayout(0),
+    entries: [
+      {
+        binding: 0,
+        resource: sourceTexture.createView(),
+      },
+      {
+        binding: 1,
+        resource: maskTexture.createView(),
+      },
+      {
+        binding: 2,
+        resource: outputTexture.createView(),
+      },
+      { binding: 3, resource: params.blurSampler },
+      { binding: 4, resource: { buffer: params.uniformBuffer } },
+    ],
+  });
+
+  // Run compute shader
+  const commandEncoder = device.createCommandEncoder();
+  const computePass = commandEncoder.beginComputePass();
+  computePass.setPipeline(params.computePipeline);
+  computePass.setBindGroup(0, bindGroup);
+
+  const workgroupCountX = Math.ceil(width / 8);
+  const workgroupCountY = Math.ceil(height / 8);
+  computePass.dispatchWorkgroups(workgroupCountX, workgroupCountY);
+  computePass.end();
+
+  // DOESN*T WORK, INTERMEDIATE SHADERS ALSO NEED TO USE 
+  //   commandEncoder.copyTextureToTexture(
+  //     { texture: outputTexture }, 
+  //     { texture: context.getCurrentTexture() },
+  //     [width, height]);
+
+  const renderPipeline = device.createRenderPipeline({
+    layout: 'auto',
+    vertex: {
+      module: params.outputRendererVertexShader,
+      entryPoint: 'main',
+    },
+    fragment: {
+      module: params.getOutputRendererFragmentShader(device, width, height),
+      entryPoint: 'main',
+      targets: [{
+        format: navigator.gpu.getPreferredCanvasFormat(),
+      }],
+    },
+    primitive: {
+      topology: 'triangle-list',
+    },
+  });
+
+  const renderBindGroup = device.createBindGroup({
+    layout: renderPipeline.getBindGroupLayout(0),
+    entries: [
+      { binding: 0, resource: outputTexture.createView() },
+      { binding: 1, resource: params.renderSampler },
+    ],
+  });
+
+  // Render to canvas
+  const canvasTexture = params.context.getCurrentTexture();
+  const renderPass = commandEncoder.beginRenderPass({
+    colorAttachments: [{
+      view: canvasTexture.createView(),
+      clearValue: { r: 0, g: 0, b: 0, a: 1 },
+      loadOp: 'clear',
+      storeOp: 'store',
+    }],
+  });
+
+  renderPass.setPipeline(renderPipeline);
+  renderPass.setBindGroup(0, renderBindGroup);
+  renderPass.draw(6);
+  renderPass.end();
+
+  device.queue.submit([commandEncoder.finish()]);
+
+  // Create a new VideoFrame from the processed WebGPU canvas
+  const processedVideoFrame = new VideoFrame(params.webgpuCanvas, {
+    timestamp: videoFrame.timestamp,
+    duration: videoFrame.duration
+  });
+
+  // Clean up textures
+  sourceTexture.destroy();
+  maskTexture.destroy();
+  outputTexture.destroy();
+
+  return processedVideoFrame;
+}
+
+// WebGPU blur renderer
+async function createWebGPUBlurRenderer(segmenter) {
+  // Always use full resolution for processing, regardless of display size
+  const webgpuCanvas = new OffscreenCanvas(1280, 720);
+
+  const adapter = await navigator.gpu.requestAdapter();
+  if (!adapter) {
+    throw new Error('WebGPU adapter not available');
+  }
+
+  const device = await adapter.requestDevice();
+  const context = webgpuCanvas.getContext('webgpu');
+
+  if (!context) {
+    throw new Error('WebGPU context not available');
+  }
+
+  context.configure({
+    device: device,
+    format: navigator.gpu.getPreferredCanvasFormat(),
+    alphaMode: 'premultiplied',
+  });
+
+  const segmentationWidth = 256;
+  const segmentationHeight = 144;
+
+  const downscaleShaderCode = `
       @group(0) @binding(0) var inputTexture: texture_2d<f32>;
       @group(0) @binding(1) var textureSampler: sampler;
       @group(0) @binding(2) var outputTexture: texture_storage_2d<rgba8unorm, write>;
@@ -244,23 +244,23 @@ async function createWebGPUBlurRenderer(segmenter) {
       }
     `;
 
-    const downscaleShader = device.createShaderModule({ code: downscaleShaderCode });
-    const downscalePipeline = device.createComputePipeline({
-      layout: 'auto',
-      compute: {
-        module: downscaleShader,
-        entryPoint: 'main',
-      },
-    });
+  const downscaleShader = device.createShaderModule({ code: downscaleShaderCode });
+  const downscalePipeline = device.createComputePipeline({
+    layout: 'auto',
+    compute: {
+      module: downscaleShader,
+      entryPoint: 'main',
+    },
+  });
 
-    const downscaleSampler = device.createSampler({
-      magFilter: 'linear',
-      minFilter: 'linear',
-    });
-    // --- Slut på nedskalningsresurser ---
+  const downscaleSampler = device.createSampler({
+    magFilter: 'linear',
+    minFilter: 'linear',
+  });
+  // --- Slut på nedskalningsresurser ---
 
-    // WebGPU compute shader for blur effect
-    const computeShaderCode = `
+  // WebGPU compute shader for blur effect
+  const computeShaderCode = `
       @group(0) @binding(0) var inputTexture: texture_2d<f32>;
       @group(0) @binding(1) var maskTexture: texture_2d<f32>;
       @group(0) @binding(2) var outputTexture: texture_storage_2d<rgba8unorm, write>;
@@ -317,34 +317,34 @@ async function createWebGPUBlurRenderer(segmenter) {
       }
     `;
 
-    const computeShader = device.createShaderModule({
-      code: computeShaderCode,
-    });
+  const computeShader = device.createShaderModule({
+    code: computeShaderCode,
+  });
 
-    const computePipeline = device.createComputePipeline({
-      layout: 'auto',
-      compute: {
-        module: computeShader,
-        entryPoint: 'main',
-      },
-    });
+  const computePipeline = device.createComputePipeline({
+    layout: 'auto',
+    compute: {
+      module: computeShader,
+      entryPoint: 'main',
+    },
+  });
 
-    const blurSampler = device.createSampler({
-        magFilter: 'linear',
-        minFilter: 'linear',
-    });
+  const blurSampler = device.createSampler({
+    magFilter: 'linear',
+    minFilter: 'linear',
+  });
 
-    const uniformBuffer = device.createBuffer({
-        // resolution: vec2<f32>, blurAmount: f32.
-        // vec2 is 8 bytes, f32 is 4. Total 12. Pad to 16 for alignment.
-        size: 16,
-        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-    });
+  const uniformBuffer = device.createBuffer({
+    // resolution: vec2<f32>, blurAmount: f32.
+    // vec2 is 8 bytes, f32 is 4. Total 12. Pad to 16 for alignment.
+    size: 16,
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  });
 
-    // Create a simple render pipeline to copy the compute shader's output (RGBA)
-    // to the canvas, which might have a different format (e.g., BGRA).
-    const outputRendererVertexShader = device.createShaderModule({
-      code: `
+  // Create a simple render pipeline to copy the compute shader's output (RGBA)
+  // to the canvas, which might have a different format (e.g., BGRA).
+  const outputRendererVertexShader = device.createShaderModule({
+    code: `
         @vertex
         fn main(@builtin(vertex_index) vertexIndex: u32) -> @builtin(position) vec4<f32> {
           var pos = array<vec2<f32>, 6>(
@@ -358,15 +358,15 @@ async function createWebGPUBlurRenderer(segmenter) {
           return vec4<f32>(pos[vertexIndex], 0.0, 1.0);
         }
       `
-    });
+  });
 
-    let outputRendererFragmentShader;
-    let lastDim;
+  let outputRendererFragmentShader;
+  let lastDim;
 
-    function getOutputRendererFragmentShader(device, width, height) {
-      if (!outputRendererFragmentShader || lastDim !== `${width}x${height}`) {
-        outputRendererFragmentShader = device.createShaderModule({
-          code: `
+  function getOutputRendererFragmentShader(device, width, height) {
+    if (!outputRendererFragmentShader || lastDim !== `${width}x${height}`) {
+      outputRendererFragmentShader = device.createShaderModule({
+        code: `
             @group(0) @binding(0) var inputTexture: texture_2d<f32>;
             @group(0) @binding(1) var textureSampler: sampler;
           
@@ -377,38 +377,38 @@ async function createWebGPUBlurRenderer(segmenter) {
             }
           `});
 
-        lastDim = `${width}x${height}`;
-      }
-      return outputRendererFragmentShader;
-    }    
+      lastDim = `${width}x${height}`;
+    }
+    return outputRendererFragmentShader;
+  }
 
-    const renderSampler = device.createSampler({
-      magFilter: 'linear',
-      minFilter: 'linear',
-    });
+  const renderSampler = device.createSampler({
+    magFilter: 'linear',
+    minFilter: 'linear',
+  });
 
-    return {
-      render: async (videoFrame) => {
-        const params = {
-          device,
-          context,
-          computePipeline,
-          webgpuCanvas,
-          blurSampler,
-          uniformBuffer,
-          outputRendererVertexShader,
-          getOutputRendererFragmentShader,
-          segmentationWidth,
-          segmentationHeight,
-          downscalePipeline,
-          downscaleSampler,
-          renderSampler,
-        };
-        try {
-          return await renderWithWebGPU(params, videoFrame);
-        } catch (error) {
-          console.warn('WebGPU rendering failed:', error);
-        }
+  return {
+    render: async (videoFrame) => {
+      const params = {
+        device,
+        context,
+        computePipeline,
+        webgpuCanvas,
+        blurSampler,
+        uniformBuffer,
+        outputRendererVertexShader,
+        getOutputRendererFragmentShader,
+        segmentationWidth,
+        segmentationHeight,
+        downscalePipeline,
+        downscaleSampler,
+        renderSampler,
+      };
+      try {
+        return await renderWithWebGPU(params, videoFrame);
+      } catch (error) {
+        console.warn('WebGPU rendering failed:', error);
       }
-    };
+    }
+  };
 }


### PR DESCRIPTION
1. Adds zero-copy import checkbox for WebGPU
2. Changing the set of radios or the checkbox lead to pipeline reinitialization
3. A zerocopy boolean is passed to webgpu pipeline creation
4. it's used to conditionally import the videoframe into an external texture, or be copied otherwise like before
5. sampling in edge shaders now happens with textureSampleBaseClampToEdge
6. bind groups & shader input textures are conditionally getting set to texture_external or texture_2d based on zero copy on or off